### PR TITLE
gitignore-fil som ignorerar alla kataloger som heter build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,4 @@
 *.dSYM/
 *.su
 
-libcomponent/build/
-libcomponent/lib/
+build/


### PR DESCRIPTION
Ska vi komma överens om en gemensam struktur för kataloger med genererade binära filer?

Själv har jag f.n. använt tre under-kataloger enligt nedan, men det kan jag ändra om ni vill ha något annat:

* lib/[biblioteks-filen som ska skapas]
* build/[exekverbara filer, t.ex. ett test-program som jag ska använda för att visa att mitt bibliotek fungerar]
* build/obj/[objekt-filer som bara används vid länkningen]

Jag har lagt in följande rader i gitignore för att undvika filerna som produceras av min makefil:
libcomponent/build/
libcomponent/lib/

Dock är det nog f.n. inte nödvändigt att ha med lib-katalogen eftersom gitignore innehåller följande rader:
*.a
*.so
(när jag skapade projektet valde jag att generera en gitignore för c-kod och då kom ovanstående rader med)

När det gäller build-katalogen så har jag f.n. valt att låta min makefil skapa ett program undan filändelse.

Ett alternativ är att ändra makefilen så att programmet skapar en filändelse med .exe eftersom *.exe redan finns med i gitignore.

Ett annat alternativ är förstås att jag skapar en egen gitignore som Marcus har gjort men i en sådan egen fil bör man bara lägga in saker som är specifika, men jag tycker alltså inte att stukturen för genererade filer bör vara specifika utan den bör vi komma överens om.

Ska vi använda en gemensam filändelse för exekverbara program?