### PR TITLE
Min ide pa hur vi gor

### DIFF
--- a/electrotest/.gitignore
+++ b/electrotest/.gitignore
@@ -1,0 +1,1 @@
+electrotest

--- a/electrotest/Makefile
+++ b/electrotest/Makefile
@@ -1,24 +1,23 @@
 CC=gcc
 CFLAGS=-std=c11 -Wall -Wextra -Werror -pedantic -g
-LFLAGS=-lpower -lresistance -lcomponent -Wl,-rpath,.
-OBJS=power.o libresistance.o libcomponent.o
-LIBS=libpower.so libresistance.so libcomponent.so
-BIN=electrotest
+LDFLAGS=-lpower -lresistance -lcomponent -lm
 DIR=lib
+LIBS=$(addprefix $(DIR)/,libpower.so libresistance.so libcomponent.so)
+BIN=electrotest
 DEST_LIB=/usr/local/lib
 DEST_BIN=/usr/local/bin
 
+.PHONY: all clean install uninstall
 
-#.PHONY: all clean install uninstall
-
-all: lib $(BIN)
+all: $(LIBS) $(BIN)
 
 clean:
 	rm -rf *.o lib electrotest
 
 install:
-	install -m 755 ./$(DIR)/*.so $(DEST_LIB)/$(LIB)
+	install -m 755 $(DIR)/*.so $(DEST_LIB)
 	install -m 755 $(BIN) $(DEST_BIN)
+	@ldconfig
 
 uninstall:
 	rm -f $(DEST_LIB)/libpower.so
@@ -26,30 +25,20 @@ uninstall:
 	rm -f $(DEST_LIB)/libcomponent.so
 	rm -f $(DEST_BIN)/$(BIN)
 
-lib: $(LIBS)
+$(DIR): 
 	mkdir -p $(DIR)
-	mv *.so $(DIR)
 
 $(BIN): electrotest.o
-	$(CC) $(CFLAGS) -o $@ main/$@.c -L./$(DIR) $(LFLAGS)/$(DIR) -lm
+	$(CC) $(CFLAGS) -o $@ $^ -L$(DIR) $(LDFLAGS)
 
-libpower.so: power.o
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ power.o
+$(DIR)/libpower.so: ../libpower/power.c ../libpower/power.h | $(DIR)
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-libresistance.so: libresistance.o
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ libresistance.o
+$(DIR)/libresistance.so: ../libresistance/src/libresistance.c ../libresistance/src/libresistance.h | $(DIR)
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-libcomponent.so: libcomponent.o
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ libcomponent.o
+$(DIR)/libcomponent.so: ../libcomponent/main/libcomponent.c ../libcomponent/main/libcomponent.h | $(DIR)
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-electrotest.o: $(OBJS)
-	$(CC) $(CFLAGS) -c -fPIC main/$*.c
-
-power.o: ../libpower/src/power.c ../libpower/src/power.h
-	$(CC) $(CFLAGS) -c -fPIC ../libpower/src/$*.c
-
-libresistance.o: ../libresistance/src/libresistance.c ../libresistance/src/libresistance.h
-	$(CC) $(CFLAGS) -c -fPIC ../libresistance/src/$*.c
-
-libcomponent.o: ../libcomponent/main/libcomponent.c ../libcomponent/main/libcomponent.h
-	$(CC) $(CFLAGS) -c -fPIC ../libcomponent/main/$*.c -lm
+electrotest.o: main/electrotest.c main/electrotest.h
+	$(CC) -I../libresistance/src -I../libcomponent/main -I../libpower $(CFLAGS) -c $<

--- a/electrotest/Makefile
+++ b/electrotest/Makefile
@@ -1,44 +1,48 @@
 CC=gcc
 CFLAGS=-std=c11 -Wall -Wextra -Werror -pedantic -g
 LDFLAGS=-lpower -lresistance -lcomponent -lm
-DIR=lib
-LIBS=$(addprefix $(DIR)/,libpower.so libresistance.so libcomponent.so)
+LIB_DIR=lib
+OBJ_DIR=obj
+LIBS=$(addprefix $(LIB_DIR)/,libpower.so libresistance.so libcomponent.so)
 BIN=electrotest
-DEST_LIB=/usr/local/lib
-DEST_BIN=/usr/local/bin
+DEST_LIB_DIR=/usr/local/lib
+DEST_BIN_DIR=/usr/local/bin
 
 .PHONY: all clean install uninstall
 
 all: $(LIBS) $(BIN)
 
 clean:
-	rm -rf *.o lib electrotest
+	rm -rf $(OBJ_DIR) $(LIB_DIR) electrotest
 
 install:
-	install -m 755 $(DIR)/*.so $(DEST_LIB)
-	install -m 755 $(BIN) $(DEST_BIN)
+	install -m 755 $(LIB_DIR)/*.so $(DEST_LIB_DIR)
+	install -m 755 $(BIN) $(DEST_BIN_DIR)
 	@ldconfig
 
 uninstall:
-	rm -f $(DEST_LIB)/libpower.so
-	rm -f $(DEST_LIB)/libresistance.so
-	rm -f $(DEST_LIB)/libcomponent.so
-	rm -f $(DEST_BIN)/$(BIN)
+	rm -f $(DEST_LIB_DIR)/libpower.so
+	rm -f $(DEST_LIB_DIR)/libresistance.so
+	rm -f $(DEST_LIB_DIR)/libcomponent.so
+	rm -f $(DEST_BIN_DIR)/$(BIN)
 
-$(DIR): 
-	mkdir -p $(DIR)
+$(LIB_DIR): 
+	mkdir -p $(LIB_DIR)
 
-$(BIN): electrotest.o
-	$(CC) $(CFLAGS) -o $@ $^ -L$(DIR) $(LDFLAGS)
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
 
-$(DIR)/libpower.so: ../libpower/power.c ../libpower/power.h | $(DIR)
+$(BIN): $(OBJ_DIR)/electrotest.o
+	$(CC) $(CFLAGS) -o $@ $^ -L$(LIB_DIR) $(LDFLAGS) -Wl,-rpath,'$$ORIGIN/$(LIB_DIR)'
+
+$(LIB_DIR)/libpower.so: ../libpower/power.c ../libpower/power.h | $(LIB_DIR)
 	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-$(DIR)/libresistance.so: ../libresistance/src/libresistance.c ../libresistance/src/libresistance.h | $(DIR)
+$(LIB_DIR)/libresistance.so: ../libresistance/src/libresistance.c ../libresistance/src/libresistance.h | $(LIB_DIR)
 	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-$(DIR)/libcomponent.so: ../libcomponent/main/libcomponent.c ../libcomponent/main/libcomponent.h | $(DIR)
+$(LIB_DIR)/libcomponent.so: ../libcomponent/main/libcomponent.c ../libcomponent/main/libcomponent.h | $(LIB_DIR)
 	$(CC) $(CFLAGS) -shared -fPIC -o $@ $^
 
-electrotest.o: main/electrotest.c main/electrotest.h
-	$(CC) -I../libresistance/src -I../libcomponent/main -I../libpower $(CFLAGS) -c $<
+$(OBJ_DIR)/electrotest.o: main/electrotest.c main/electrotest.h | $(OBJ_DIR)
+	$(CC) -I../libresistance/src -I../libcomponent/main -I../libpower $(CFLAGS) -c -o $@ $<

--- a/electrotest/main/electrotest.h
+++ b/electrotest/main/electrotest.h
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include "../../libpower/src/power.h"
-#include "../../libresistance/src/libresistance.h"
-#include "../../libcomponent/main/libcomponent.h"
+#include "power.h"
+#include "libresistance.h"
+#include "libcomponent.h"
 
 #define MAXWORDS 1024
 


### PR DESCRIPTION
fixes #12 

Detta är ett förslag på hur vi skulle kunna göra. Biblioteken byggs fortfarande på nytt i electrotest då det är tvetydigt hur det skall vara. Länkning sker mot dessa lokala bibliotek. Men tanken är ju att applikationen skall installeras och appen sedan "by convention" ska använda biblioteken i /usr/local/lib....

Den förra Makefilen hade lite tokiga saker i mitt tycke (men kom gärna med input och ändra fritt :) )

1. Targets för mappen lib flyttade so-filerna vilket gjorde att allting alltid byggdes om då dessa är borta nästa gång make invokas. Jag gjorde en order-only prereq på biblioteket för resp. bibliotek och la pathen framför resp. bibliotek med $addprefix

2. include direktiven i electrotest.h använda djupa relativa sökvägar. Jag ändrade till utan path för att mer återspegla hur det normalt kan se ut när man använder bibliotek. -I-flaggan vid kompilering pekar sedan ut mappar för resp. header.

3. Jag får backa på det jag sa tidigare. Efter att ha läst lite mer så verkar det som att lärararna vill ha det till att binären skall kunna köras utan att installeras. Ändrade även länkningsdirektivet mot origin. 

Så....hur som haver, jag la då till ett anrop till ldconfig så att linux uppdaterar och ser de nyinstallerade biblioteken på en gång.

4. Kortade ner Makefile:en litegrann. Tog bort mellanstegen för objektsfilerna för biblioteken....


Ett litet förslag på ett första utkast iaf :)

Synpunkter? Nån annan får gärna merga vid samtycke...
